### PR TITLE
Use multitaper instead mtspec + Use ARIMA instead ARMA

### DIFF
--- a/oscina/ar_surr.py
+++ b/oscina/ar_surr.py
@@ -72,9 +72,9 @@ def ar_surr(x, fs, k_perm, freq_cutoff=15, correction='cluster'):
     x = sm.tsa.tsatools.detrend(x, order=detrend_ord)
 
     # Estimate an AR model
-    mdl_order = (1, 0)
-    mdl = sm.tsa.ARMA(x, mdl_order)
-    result = mdl.fit(trend='c', disp=0)
+    mdl_order = (1, 0, 0)
+    mdl = sm.tsa.ARIMA(x, order=mdl_order, trend='c')
+    result = mdl.fit()
     result.summary()
     # Make a generative model using the AR parameters
     arma_process = sm.tsa.ArmaProcess.from_coeffs(result.arparams)

--- a/oscina/robust_est.py
+++ b/oscina/robust_est.py
@@ -2,7 +2,7 @@ import numpy as np
 import statsmodels.api as sm
 from statsmodels.stats.multitest import multipletests
 from scipy import stats
-from mtspec import mtspec
+import multitaper
 from scipy.ndimage import median_filter
 from scipy.optimize import curve_fit
 
@@ -62,11 +62,17 @@ def robust_est(x, fs, nw=1.5, n_tapers=None,
     # Compute spectrum using multitapers
     if n_tapers is None:  # Number of tapers
         n_tapers = int(2 * nw) - 1
-    spec, freq = mtspec(data=x,
-                        delta=fs ** -1,
-                        time_bandwidth=nw,
-                        number_of_tapers=n_tapers,
-                        statistics=False, rshape=0)
+    mt = multitaper.MTSpec(
+            x=x,
+            nw=nw,
+            kspec=n_tapers,
+            dt=fs ** -1,
+            nfft=len(x),
+            iadapt=0,
+    )
+    freq, spec = mt.rspec()
+    freq = freq.ravel()
+    spec = spec.ravel()
 
     # Smooth the spectrum with a median filter
     spec_filt = median_filter(spec, med_filt_win)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ matplotlib
 multitaper
 numpy
 scikit-image
-scipy
+scipy>=1.10.0
 statsmodels

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
-numpy==1.18.1
-PyYAML==6.0
-scikit-image==0.17.2
-scipy==1.4.1
-statsmodels==0.11.0
+PyYAML
+jupyterlab
+matplotlib
+multitaper
+numpy
+scikit-image
+scipy
+statsmodels


### PR DESCRIPTION
This brings in changes from @samuelgarcia, originally submitted in this PR: 
https://github.com/gbrookshire/simulated_rhythmic_sampling/pull/1

>     multitaperinstead of mtspec (no maintened anymore)
>     statsmodels ARIMA instead of ARMA
